### PR TITLE
Add some subcommand and some templates

### DIFF
--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -1,6 +1,7 @@
 require "goa_model_gen"
 
 require "erb"
+require "pathname"
 
 require "thor"
 
@@ -9,6 +10,21 @@ require "goa_model_gen/generator"
 
 module GoaModelGen
   class Cli < Thor
+    class << self
+      def default_go_package!
+        gopath = ENV['GOPATH'] || ''
+        raise "$GOPATH not found" if gopath.empty?
+        return Pathname.new(Dir.pwd).relative_path_from(Pathname.new(File.join(gopath, "src"))).to_s
+      end
+
+      def default_go_package
+        return default_go_package!
+      rescue
+        nil
+      end
+    end
+
+    class_option :go_package, type: :string, default: default_go_package, desc: 'Base go package name'
     class_option :swagger_yaml, type: :string, default: './swagger/swagger.yaml', desc: 'Swagger definition YAML file'
 
     desc "show FILE1...", "Show model info from definition files"

--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -24,7 +24,7 @@ module GoaModelGen
       {
         "templates/goon.go.erb" => "model/goon.go",
       }.each do |template, dest|
-        generator.run(template, dest)
+        generator.run(template, dest, overwrite: true)
       end
     end
 
@@ -43,7 +43,7 @@ module GoaModelGen
       load_types_for(paths) do |path, types|
         generator = new_generator.tap{|g| g.types = types }
         dest = File.join(cfg.model_dir, File.basename(path, ".*") + ".go")
-        generator.run('templates/model.go.erb', dest)
+        generator.run('templates/model.go.erb', dest, overwrite: true)
       end
     end
 
@@ -54,7 +54,7 @@ module GoaModelGen
         generator = new_generator.tap{|g| g.types = types }
         dest = File.join(cfg.controller_dir, File.basename(path, ".*") + "_conv.go")
         if types.any?{|t| !!t.payload || !!t.media_type}
-          generator.run('templates/converter.go.erb', dest)
+          generator.run('templates/converter.go.erb', dest, overwrite: true)
         end
       end
     end

--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -28,10 +28,10 @@ module GoaModelGen
     option :dir, type: :string, default: './model', desc: 'Output directory path'
     option :gofmt, type: :boolean, default: true, desc: 'Run gofmt for generated file'
     def model(*paths)
-      generator = new_generator('templates/model.go.erb')
+      generator = new_generator
       load_types_for(paths, options[:swagger_yaml]) do |path, types|
         dest = File.join(options[:dir], File.basename(path, ".*") + ".go")
-        generator.run(types, dest)
+        generator.run('templates/model.go.erb', types, dest)
         if options[:gofmt]
           system("gofmt -w #{dest}")
         end
@@ -43,11 +43,11 @@ module GoaModelGen
     option :dir, type: :string, default: './controller', desc: 'Output directory path'
     option :gofmt, type: :boolean, default: true, desc: 'Run gofmt for generated file'
     def converter(*paths)
-      generator = new_generator('templates/converter.go.erb')
+      generator = new_generator
       load_types_for(paths, options[:swagger_yaml]) do |path, types|
         dest = File.join(options[:dir], File.basename(path, ".*") + "_conv.go")
         if types.any?{|t| !!t.payload || !!t.media_type}
-          generator.run(types, dest)
+          generator.run('templates/converter.go.erb', types, dest)
           if options[:gofmt]
             system("gofmt -w #{dest}")
           end
@@ -56,11 +56,11 @@ module GoaModelGen
     end
 
     no_commands do
-      def new_generator(rel_path)
+      def new_generator
         opts = {
           go_package: options[:go_package],
         }
-        GoaModelGen::Generator.new(File.expand_path('../' + rel_path, __FILE__), opts)
+        GoaModelGen::Generator.new(opts)
       end
 
 

--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -23,6 +23,7 @@ module GoaModelGen
       generator = new_generator
       {
         "templates/goon.go.erb" => "model/goon.go",
+        "templates/converter_base.go.erb" => "controller/converter_base.go",
       }.each do |template, dest|
         generator.run(template, dest, overwrite: true)
       end

--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -30,10 +30,10 @@ module GoaModelGen
     desc "model FILE1...", "Generate model files from definition files"
     def model(*paths)
       show_version_if_required
-      generator = new_generator
       load_types_for(paths) do |path, types|
+        generator = new_generator.tap{|g| g.types = types }
         dest = File.join(cfg.model_dir, File.basename(path, ".*") + ".go")
-        generator.run('templates/model.go.erb', types, dest)
+        generator.run('templates/model.go.erb', dest)
         system("gofmt -w #{dest}") unless cfg.gofmt_disabled
       end
     end
@@ -41,11 +41,11 @@ module GoaModelGen
     desc "converter FILE1...", "Generate converter files from definition files and swagger.yaml"
     def converter(*paths)
       show_version_if_required
-      generator = new_generator
       load_types_for(paths) do |path, types|
+        generator = new_generator.tap{|g| g.types = types }
         dest = File.join(cfg.controller_dir, File.basename(path, ".*") + "_conv.go")
         if types.any?{|t| !!t.payload || !!t.media_type}
-          generator.run('templates/converter.go.erb', types, dest)
+          generator.run('templates/converter.go.erb', dest)
           system("gofmt -w #{dest}") unless cfg.gofmt_disabled
         end
       end

--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -2,19 +2,19 @@ require "goa_model_gen"
 
 require "thor"
 
+require "goa_model_gen/config"
 require "goa_model_gen/loader"
 require "goa_model_gen/generator"
 
 module GoaModelGen
   class Cli < Thor
+    class_option :config, type: :string, aliases: 'c', default: './goa_model_gen.yaml', desc: 'Path to config file. You can generate it by config subcommand'
+
     desc "config", "Generate config file"
-    option :path, type: :string, default: './goa_model_gen.yaml', desc: 'Path to config file'
-    def config
+    def config(path = './goa_model_gen.yaml')
       open(path, 'w'){|f| f.puts(Config.new.fulfill.to_yaml) }
     end
 
-    class_option :go_package, type: :string, default: default_go_package, desc: 'Base go package name'
-    class_option :swagger_yaml, type: :string, default: './swagger/swagger.yaml', desc: 'Swagger definition YAML file'
 
     desc "show FILE1...", "Show model info from definition files"
     def show(*paths)
@@ -25,47 +25,38 @@ module GoaModelGen
     end
 
     desc "model FILE1...", "Generate model files from definition files"
-    option :dir, type: :string, default: './model', desc: 'Output directory path'
-    option :gofmt, type: :boolean, default: true, desc: 'Run gofmt for generated file'
     def model(*paths)
       generator = new_generator
       load_types_for(paths) do |path, types|
-        dest = File.join(options[:dir], File.basename(path, ".*") + ".go")
+        dest = File.join(cfg.model_dir, File.basename(path, ".*") + ".go")
         generator.run('templates/model.go.erb', types, dest)
-        if options[:gofmt]
-          system("gofmt -w #{dest}")
-        end
+        system("gofmt -w #{dest}") unless cfg.gofmt_disabled
       end
     end
 
     desc "converter FILE1...", "Generate converter files from definition files and swagger.yaml"
-    option :package, type: :string, default: 'controller', desc: 'package name'
-    option :dir, type: :string, default: './controller', desc: 'Output directory path'
-    option :gofmt, type: :boolean, default: true, desc: 'Run gofmt for generated file'
     def converter(*paths)
       generator = new_generator
       load_types_for(paths) do |path, types|
-        dest = File.join(options[:dir], File.basename(path, ".*") + "_conv.go")
+        dest = File.join(cfg.controller_dir, File.basename(path, ".*") + "_conv.go")
         if types.any?{|t| !!t.payload || !!t.media_type}
           generator.run('templates/converter.go.erb', types, dest)
-          if options[:gofmt]
-            system("gofmt -w #{dest}")
-          end
+          system("gofmt -w #{dest}") unless cfg.gofmt_disabled
         end
       end
     end
 
     no_commands do
-      def config
-        @config ||= GoaModelGen::Config.new.load_from(options[:config)
+      def cfg
+        @cfg ||= GoaModelGen::Config.new.load_from(options[:config])
       end
 
       def new_generator
-        GoaModelGen::Generator.new(config)
+        GoaModelGen::Generator.new(cfg)
       end
 
       def load_types_for(paths)
-        swagger_loader = GoaModelGen::SwaggerLoader.new(config.swagger_yaml)
+        swagger_loader = GoaModelGen::SwaggerLoader.new(cfg.swagger_yaml)
         path_to_types = {}
         defined_types = {}
         paths.each do |path|

--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -42,8 +42,13 @@ module GoaModelGen
       show_version_if_required
       load_types_for(paths) do |path, types|
         generator = new_generator.tap{|g| g.types = types }
-        dest = File.join(cfg.model_dir, File.basename(path, ".*") + ".go")
-        generator.run('templates/model.go.erb', dest, overwrite: true)
+        [
+          {path: 'templates/model.go.erb', suffix: '.go', overwrite: true},
+          {path: 'templates/model_validation.go.erb', suffix: '_validation.go', overwrite: false},
+        ].each do |d|
+          dest = File.join(cfg.model_dir, File.basename(path, ".*") + d[:suffix])
+          generator.run(d[:path], dest, overwrite: d[:overwrite])
+        end
       end
     end
 

--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -17,6 +17,16 @@ module GoaModelGen
       open(path, 'w'){|f| f.puts(Config.new.fulfill.to_yaml) }
     end
 
+    desc "bootstrap", "Generate files not concerned with model"
+    def bootstrap
+      show_version_if_required
+      generator = new_generator
+      {
+        "templates/goon.go.erb" => "model/goon.go",
+      }.each do |template, dest|
+        generator.run(template, dest)
+      end
+    end
 
     desc "show FILE1...", "Show model info from definition files"
     def show(*paths)

--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -8,16 +8,19 @@ require "goa_model_gen/generator"
 
 module GoaModelGen
   class Cli < Thor
+    class_option :version, type: :boolean, aliases: 'v', desc: 'Show version before processing'
     class_option :config, type: :string, aliases: 'c', default: './goa_model_gen.yaml', desc: 'Path to config file. You can generate it by config subcommand'
 
     desc "config", "Generate config file"
     def config(path = './goa_model_gen.yaml')
+      show_version_if_required
       open(path, 'w'){|f| f.puts(Config.new.fulfill.to_yaml) }
     end
 
 
     desc "show FILE1...", "Show model info from definition files"
     def show(*paths)
+      show_version_if_required
       load_types_for(paths) do |path, types|
         puts "types in #{path}"
         puts YAML.dump(types)
@@ -26,6 +29,7 @@ module GoaModelGen
 
     desc "model FILE1...", "Generate model files from definition files"
     def model(*paths)
+      show_version_if_required
       generator = new_generator
       load_types_for(paths) do |path, types|
         dest = File.join(cfg.model_dir, File.basename(path, ".*") + ".go")
@@ -36,6 +40,7 @@ module GoaModelGen
 
     desc "converter FILE1...", "Generate converter files from definition files and swagger.yaml"
     def converter(*paths)
+      show_version_if_required
       generator = new_generator
       load_types_for(paths) do |path, types|
         dest = File.join(cfg.controller_dir, File.basename(path, ".*") + "_conv.go")
@@ -46,7 +51,20 @@ module GoaModelGen
       end
     end
 
+    desc "version", "Show version"
+    def version
+      show_version
+    end
+
     no_commands do
+      def show_version_if_required
+        show_version if options[:version]
+      end
+
+      def show_version
+        puts "#{$PROGRAM_NAME} version:#{::GoaModelGen::VERSION}"
+      end
+
       def cfg
         @cfg ||= GoaModelGen::Config.new.load_from(options[:config])
       end

--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -39,7 +39,7 @@ module GoaModelGen
     option :dir, type: :string, default: './model', desc: 'Output directory path'
     option :gofmt, type: :boolean, default: true, desc: 'Run gofmt for generated file'
     def model(*paths)
-      generator = GoaModelGen::Generator.new(File.expand_path('../templates/model.go.erb', __FILE__))
+      generator = new_generator('templates/model.go.erb')
       load_types_for(paths, options[:swagger_yaml]) do |path, types|
         dest = File.join(options[:dir], File.basename(path, ".*") + ".go")
         generator.run(types, dest)
@@ -54,7 +54,7 @@ module GoaModelGen
     option :dir, type: :string, default: './controller', desc: 'Output directory path'
     option :gofmt, type: :boolean, default: true, desc: 'Run gofmt for generated file'
     def converter(*paths)
-      generator = GoaModelGen::Generator.new(File.expand_path('../templates/converter.go.erb', __FILE__))
+      generator = new_generator('templates/converter.go.erb')
       load_types_for(paths, options[:swagger_yaml]) do |path, types|
         dest = File.join(options[:dir], File.basename(path, ".*") + "_conv.go")
         if types.any?{|t| !!t.payload || !!t.media_type}
@@ -67,6 +67,10 @@ module GoaModelGen
     end
 
     no_commands do
+      def new_generator(rel_path)
+        GoaModelGen::Generator.new(File.expand_path('../' + rel_path, __FILE__))
+      end
+
 
       def load_types_for(paths, swagger_yaml)
         swagger_loader = GoaModelGen::SwaggerLoader.new(swagger_yaml)

--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -44,7 +44,6 @@ module GoaModelGen
         generator = new_generator.tap{|g| g.types = types }
         dest = File.join(cfg.model_dir, File.basename(path, ".*") + ".go")
         generator.run('templates/model.go.erb', dest)
-        system("gofmt -w #{dest}") unless cfg.gofmt_disabled
       end
     end
 
@@ -56,7 +55,6 @@ module GoaModelGen
         dest = File.join(cfg.controller_dir, File.basename(path, ".*") + "_conv.go")
         if types.any?{|t| !!t.payload || !!t.media_type}
           generator.run('templates/converter.go.erb', dest)
-          system("gofmt -w #{dest}") unless cfg.gofmt_disabled
         end
       end
     end

--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -1,8 +1,5 @@
 require "goa_model_gen"
 
-require "erb"
-require "pathname"
-
 require "thor"
 
 require "goa_model_gen/loader"
@@ -10,18 +7,10 @@ require "goa_model_gen/generator"
 
 module GoaModelGen
   class Cli < Thor
-    class << self
-      def default_go_package!
-        gopath = ENV['GOPATH'] || ''
-        raise "$GOPATH not found" if gopath.empty?
-        return Pathname.new(Dir.pwd).relative_path_from(Pathname.new(File.join(gopath, "src"))).to_s
-      end
-
-      def default_go_package
-        return default_go_package!
-      rescue
-        nil
-      end
+    desc "config", "Generate config file"
+    option :path, type: :string, default: './goa_model_gen.yaml', desc: 'Path to config file'
+    def config
+      open(path, 'w'){|f| f.puts(Config.new.fulfill.to_yaml) }
     end
 
     class_option :go_package, type: :string, default: default_go_package, desc: 'Base go package name'

--- a/lib/goa_model_gen/cli.rb
+++ b/lib/goa_model_gen/cli.rb
@@ -68,7 +68,10 @@ module GoaModelGen
 
     no_commands do
       def new_generator(rel_path)
-        GoaModelGen::Generator.new(File.expand_path('../' + rel_path, __FILE__))
+        opts = {
+          go_package: options[:go_package],
+        }
+        GoaModelGen::Generator.new(File.expand_path('../' + rel_path, __FILE__), opts)
       end
 
 

--- a/lib/goa_model_gen/config.rb
+++ b/lib/goa_model_gen/config.rb
@@ -1,0 +1,66 @@
+require "goa_model_gen"
+
+require "erb"
+require "yaml"
+require "pathname"
+
+require "active_support/core_ext/string"
+
+module GoaModelGen
+  class Config
+
+    ATTRIBUTES = %w[
+      go_package
+      swagger_yaml
+      gofmt_disabled
+      model_dir
+      controller_dir
+    ].freeze
+
+    attr_reader *ATTRIBUTES
+
+    def fulfill
+      @go_package     ||= default_go_package
+      @swagger_yaml   ||= "./swagger/swagger.yaml"
+      @gofmt_disabled ||= false
+      @model_dir      ||= "./model"
+      @controller_dir ||= "./controller"
+      self
+    end
+
+    def load_from(path)
+      erb = ERB.new(File.read(path), nil, "-")
+      erb.filename = path
+      config = YAML.load(erb.result, path)
+
+      ATTRIBUTES.each do |name|
+        instance_variable_set("@#{name}", config[name].presence)
+      end
+
+      fulfill
+    end
+
+    def to_hash
+      ATTRIBUTES.each_with_object({}) do |name, d|
+        d[name] = send(name)
+      end
+    end
+
+    def to_yaml
+      YAML.dump(to_hash)
+    end
+
+    def default_go_package
+      return default_go_package!
+    rescue
+      nil
+    end
+
+    def default_go_package!
+      gopath = ENV['GOPATH'] || ''
+      raise "$GOPATH not found" if gopath.empty?
+      return Pathname.new(Dir.pwd).relative_path_from(Pathname.new(File.join(gopath, "src"))).to_s
+    end
+
+  end
+end

--- a/lib/goa_model_gen/generator.rb
+++ b/lib/goa_model_gen/generator.rb
@@ -9,14 +9,15 @@ module GoaModelGen
   class Generator
     attr_reader :go_package
 
-    def initialize(template_path, options = {})
-      @erb = ERB.new(File.read(template_path), nil, "-")
-      @erb.filename = template_path
+    def initialize(options = {})
       @go_package = options[:go_package]
     end
 
-    def run(types, path)
-      content = @erb.result(binding)
+    def run(rel_path, types, path)
+      abs_path = File.expand_path('../' + rel_path, __FILE__)
+      erb = ERB.new(File.read(abs_path), nil, "-")
+      erb.filename = abs_path
+      content = erb.result(binding)
       open(path, 'w'){|f| f.puts(content) }
     end
 

--- a/lib/goa_model_gen/generator.rb
+++ b/lib/goa_model_gen/generator.rb
@@ -15,7 +15,8 @@ module GoaModelGen
       @config = config
     end
 
-    def run(rel_path, path)
+    def run(rel_path, path, overwrite: false)
+      return if File.exist?(path) && !overwrite
       abs_path = File.expand_path('../' + rel_path, __FILE__)
       erb = ERB.new(File.read(abs_path), nil, "-")
       erb.filename = abs_path

--- a/lib/goa_model_gen/generator.rb
+++ b/lib/goa_model_gen/generator.rb
@@ -7,10 +7,10 @@ require "active_support/core_ext/string"
 
 module GoaModelGen
   class Generator
-    attr_reader :go_package
+    attr_reader :config
 
-    def initialize(options = {})
-      @go_package = options[:go_package]
+    def initialize(config)
+      @config = config
     end
 
     def run(rel_path, types, path)

--- a/lib/goa_model_gen/generator.rb
+++ b/lib/goa_model_gen/generator.rb
@@ -7,13 +7,15 @@ require "active_support/core_ext/string"
 
 module GoaModelGen
   class Generator
+    # These are used in templates
     attr_reader :config
+    attr_accessor :types
 
     def initialize(config)
       @config = config
     end
 
-    def run(rel_path, types, path)
+    def run(rel_path, path)
       abs_path = File.expand_path('../' + rel_path, __FILE__)
       erb = ERB.new(File.read(abs_path), nil, "-")
       erb.filename = abs_path

--- a/lib/goa_model_gen/generator.rb
+++ b/lib/goa_model_gen/generator.rb
@@ -21,6 +21,9 @@ module GoaModelGen
       erb.filename = abs_path
       content = erb.result(binding)
       open(path, 'w'){|f| f.puts(content) }
+      if (File.extname(path) == '.go') && !config.gofmt_disabled
+        system("gofmt -w #{path}")
+      end
     end
 
   end

--- a/lib/goa_model_gen/generator.rb
+++ b/lib/goa_model_gen/generator.rb
@@ -7,10 +7,12 @@ require "active_support/core_ext/string"
 
 module GoaModelGen
   class Generator
-    def initialize(template_path)
-      content = File
+    attr_reader :go_package
+
+    def initialize(template_path, options = {})
       @erb = ERB.new(File.read(template_path), nil, "-")
       @erb.filename = template_path
+      @go_package = options[:go_package]
     end
 
     def run(types, path)

--- a/lib/goa_model_gen/templates/converter.go.erb
+++ b/lib/goa_model_gen/templates/converter.go.erb
@@ -1,8 +1,8 @@
 package controller
 
 import (
-	"github.com/groovenauts/blocks-concurrent-batch-server/app"
-	"github.com/groovenauts/blocks-concurrent-batch-server/model"
+	"<%= go_package %>/app"
+	"<%= go_package %>/model"
 )
 
 <%- types.select(&:gen_converter?).each do |type| -%>

--- a/lib/goa_model_gen/templates/converter.go.erb
+++ b/lib/goa_model_gen/templates/converter.go.erb
@@ -1,8 +1,8 @@
 package controller
 
 import (
-	"<%= go_package %>/app"
-	"<%= go_package %>/model"
+	"<%= config.go_package %>/app"
+	"<%= config.go_package %>/model"
 )
 
 <%- types.select(&:gen_converter?).each do |type| -%>

--- a/lib/goa_model_gen/templates/converter_base.go.erb
+++ b/lib/goa_model_gen/templates/converter_base.go.erb
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"strconv"
+)
+
+func BoolPointerToBool(v *bool) bool {
+	return BoolPointerToBoolWith(v, false)
+}
+
+func BoolPointerToBoolWith(v *bool, d bool) bool {
+	if v == nil {
+		return d
+	}
+	return *v
+}
+
+func IntPointerToInt(v *int) int {
+	return IntPointerToIntWith(v, 0)
+}
+
+func IntPointerToIntWith(v *int, d int) int {
+	if v == nil {
+		return d
+	}
+	return *v
+}
+
+func IntToInt64(v int) int64 {
+	return int64(v)
+}
+
+func IntToInt64Pointer(v int) *int64 {
+	r := IntToInt64(v)
+	return &r
+}
+
+func StringPointerToString(v *string) string {
+	return StringPointerToStringWith(v, "")
+}
+
+func StringPointerToStringWith(v *string, d string) string {
+	if v == nil {
+		return d
+	}
+	return *v
+}
+
+func StringToInt64(v string) (int64, error) {
+	return strconv.ParseInt(v, 10, 64)
+}
+
+func Int64ToString(v int64) string {
+	return strconv.FormatInt(v, 10)
+}
+
+func Int64ToStringPointer(v int64) *string {
+	s := Int64ToString(v)
+	return &s
+}

--- a/lib/goa_model_gen/templates/goon.go.erb
+++ b/lib/goa_model_gen/templates/goon.go.erb
@@ -1,0 +1,27 @@
+package model
+
+import (
+	"golang.org/x/net/context"
+
+	"github.com/mjibson/goon"
+)
+
+// // Use the following code if you want to change kind name from model struct name.
+// var ModelNameToKindMap = map[string]string{
+// 	"Person": "People",
+// 	"Book":   "Books",
+// }
+
+func GoonFromContext(c context.Context) *goon.Goon {
+	r := goon.FromContext(c)
+	// baseResolver := r.KindNameResolver
+	// r.KindNameResolver = func(src interface{}) string {
+	// 	base := baseResolver(src)
+	// 	mapped := ModelNameToKindMap[base]
+	// 	if mapped != "" {
+	// 		return mapped
+	// 	}
+	// 	return base
+	// }
+	return r
+}

--- a/lib/goa_model_gen/templates/model.go.erb
+++ b/lib/goa_model_gen/templates/model.go.erb
@@ -196,7 +196,7 @@ func (s *<%= store_name %>) Create(ctx context.Context, m *<%= model.name %>) (*
 	}
 	if exist {
 		log.Errorf(ctx, "Failed to create %v because of another entity has same key\n", m)
-		return nil, fmt.Errorf("Duplicate Name error: %q of %v\n", m.Name, m)
+		return nil, fmt.Errorf("Duplicate <%= model.goon['id_name'] %> error: %q of %v\n", m.<%= model.goon['id_name'] %>, m)
 	}
 <%- end -%>
 
@@ -219,7 +219,7 @@ func (s *<%= store_name %>) Update(ctx context.Context, m *<%= model.name %>) (*
 	}
 	if !exist {
 		log.Errorf(ctx, "Failed to update %v because it doesn't exist\n", m)
-		return nil, fmt.Errorf("No data to update %q of %v\n", m.Name, m)
+		return nil, fmt.Errorf("No data to update %q of %v\n", m.<%= model.goon['id_name'] %>, m)
 	}
 <%- end -%>
 

--- a/lib/goa_model_gen/templates/model_validation.go.erb
+++ b/lib/goa_model_gen/templates/model_validation.go.erb
@@ -1,0 +1,13 @@
+package model
+
+import (
+	"gopkg.in/go-playground/validator.v9"
+)
+
+<%- types.select(&:store?).each do |model| -%>
+func (m *<%= model.name %>) Validate() error {
+	validator := validator.New()
+	return validator.Struct(m)
+}
+
+<%- end -%>

--- a/lib/goa_model_gen/version.rb
+++ b/lib/goa_model_gen/version.rb
@@ -1,3 +1,3 @@
 module GoaModelGen
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
## Config file

Use config file instead of class_options

## New sub-commands

- `config`
    - Generate default config file
- bootstrap
    - Generate static files
        - `model/goo.go`
        - `controller/converter_base.go`

## Templates

- `model/xxxx_validation.go`

## Others

- Use Config class and config file instead of lots of options
- Fix some bugs